### PR TITLE
fix: UrlBindingConflictException while using similar URIs

### DIFF
--- a/stripes/src/net/sourceforge/stripes/controller/UrlBindingFactory.java
+++ b/stripes/src/net/sourceforge/stripes/controller/UrlBindingFactory.java
@@ -187,7 +187,7 @@ public class UrlBindingFactory {
                 minComponentCount = componentCount;
                 maxComponentMatch = componentMatch;
             }
-            else if (idx == maxIndex && componentCount == minComponentCount) {
+            else if (idx == maxIndex && componentCount == minComponentCount && componentMatch == maxComponentMatch) {
                 if (conflicts == null) {
                     conflicts = new ArrayList<String>(candidates.size());
                     conflicts.add(prototype.toString());


### PR DESCRIPTION
If you use similar URIs like "/path/{name}-xx{id}.html" and "/path/{name}-yy{id}.html" on different action beans you'll get an UrlBindingConflictException, because the condition to count the conflicts do not check the component match count. Both URIs hold the same component count but only one of them will have the greater component match count.