### PR TITLE
fix: detecting a non-existing resource for POST requests on wildfly 8 (STS-916)

### DIFF
--- a/stripes/src/net/sourceforge/stripes/controller/DynamicMappingFilter.java
+++ b/stripes/src/net/sourceforge/stripes/controller/DynamicMappingFilter.java
@@ -406,7 +406,7 @@ public class DynamicMappingFilter implements Filter {
 
         // If a FileNotFoundException or SC_NOT_FOUND error occurred, then try to match an ActionBean to the URL
         Integer errorCode = wrapper.getErrorCode();
-        if (!initializing && (errorCode != null && errorCode == HttpServletResponse.SC_NOT_FOUND)
+        if (!initializing && (errorCode != null && (errorCode == HttpServletResponse.SC_NOT_FOUND || errorCode == HttpServletResponse.SC_METHOD_NOT_ALLOWED))
                 || fileNotFoundExceptionThrown) {
             // Get a reference to a StripesFilter instance
             StripesFilter sf = getStripesFilter();


### PR DESCRIPTION
this fix issue STP-916 (http://www.stripesframework.org/jira/browse/STS-916)

> DynamicMappingFilter detects a non-existing resource by catching FileNotFoundException and by controlling whether the HTTP return code for the resource is 404. Unfortunately, in WildFly, the default servlet returns 405 (method not allowed) for POST requests; therefore DynamicMappingFilter does not invoke any Stripes action for those requests, returning 405 to the client instead.
> 
> Since the DispatcherServlet understands both GET and POST, imho 405 should always be interpreted as resource not found as well, and the request handled with the DispatcherServlet.
