### PR TITLE
STS-695 - Make FlashScope.request transient for serialization

### DIFF
--- a/stripes/src/main/java/net/sourceforge/stripes/controller/FlashScope.java
+++ b/stripes/src/main/java/net/sourceforge/stripes/controller/FlashScope.java
@@ -90,7 +90,7 @@ public class FlashScope extends HashMap<String,Object> {
     private static final Random random = new Random();
     private long startTime;
     private int timeout = DEFAULT_TIMEOUT_IN_SECONDS;
-    private HttpServletRequest request;
+    private transient HttpServletRequest request;
     private Integer key;
     private Semaphore semaphore;
 


### PR DESCRIPTION
Allow FlashScope to be serializable when request (HttpServletRequest) field is non-null. This allows HttpSession's to be serialized in multi-server shared-nothing configurations.