### PR TITLE
* Additional fix for STS-919.  Unit tests caught an issue where case-…

### DIFF
--- a/stripes/src/main/java/net/sourceforge/stripes/mock/MockHttpServletRequest.java
+++ b/stripes/src/main/java/net/sourceforge/stripes/mock/MockHttpServletRequest.java
@@ -135,8 +135,10 @@ public class MockHttpServletRequest implements HttpServletRequest {
 
     /** Gets the named header as an int. Must have been set as an Integer with addHeader(). */
     public int getIntHeader(String name) {
-        if( !this.headers.containsKey(name) ) return -1;
-        return (Integer) this.headers.get(name);    }
+        String headerValue = getHeader( name );
+        if( headerValue == null ) return -1;
+        return Integer.parseInt( headerValue );
+    }
 
     /** Sets the method used by the request. Defaults to POST. */
     public void setMethod(String method) { this.method = method; }

--- a/stripes/src/test/java/net/sourceforge/stripes/util/ReflectUtilTest.java
+++ b/stripes/src/test/java/net/sourceforge/stripes/util/ReflectUtilTest.java
@@ -28,15 +28,6 @@ public class ReflectUtilTest {
         Map.Entry<String,String> entry = map.entrySet().iterator().next();
         PropertyDescriptor pd = ReflectUtil.getPropertyDescriptor(entry.getClass(), "value");
         Method m = pd.getReadMethod();
-
-        // The returned method should fail
-        try {
-            m.invoke(entry);
-            Assert.fail("Method should have thrown an illegal access exception!");
-        }
-        catch (IllegalAccessException iae) { /* This is expected. */ }
-
-        // Now try doing it right!
         m = ReflectUtil.findAccessibleMethod(m);
         String value = (String) m.invoke(entry);
         Assert.assertEquals(value, "bar");

--- a/stripes/src/test/java/net/sourceforge/stripes/validation/ValidationWithGenericsTest.java
+++ b/stripes/src/test/java/net/sourceforge/stripes/validation/ValidationWithGenericsTest.java
@@ -1,16 +1,12 @@
 package net.sourceforge.stripes.validation;
 
 import net.sourceforge.stripes.FilterEnabledTestBase;
-import net.sourceforge.stripes.StripesTestFixture;
 import net.sourceforge.stripes.action.ActionBean;
 import net.sourceforge.stripes.action.ActionBeanContext;
 import net.sourceforge.stripes.action.Resolution;
 import net.sourceforge.stripes.mock.MockRoundtrip;
 
-import net.sourceforge.stripes.mock.MockServletContext;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**


### PR DESCRIPTION
…insensitive header accessor was not being used in getHeaderAsInt().  Changed this method to use the internal getHeader() method.

* Removed assertion from ReflectUtilTest that Map.getValue() is not an invokeable read method.  Checking the source in OpenJDK, it is public.  Regardless, this assertion is useless since this test is supposed to test whether or not ReflectUtil can execute the read method.
* Removed unused imports from ValidationWithGenericsTest