### PR TITLE
revert injectbeans to previous behaviour, where the application won't fail if there isn't an applicationContext present

### DIFF
--- a/stripes/src/main/java/net/sourceforge/stripes/integration/spring/SpringHelper.java
+++ b/stripes/src/main/java/net/sourceforge/stripes/integration/spring/SpringHelper.java
@@ -93,11 +93,10 @@ public class SpringHelper {
 
         if (ac == null) {
             final String name = ctx.getServletContextName();
-            throw new IllegalStateException(
-                    "No Spring application context was found in servlet context \"" + name + "\"");
+            log.warn( "No Spring application context was found in servlet context \"" + name + "\"" );
+        } else {
+            injectBeans(bean, ac);
         }
-
-        injectBeans(bean, ac);
     }
 
     /**


### PR DESCRIPTION
As discussed on https://github.com/StripesFramework/stripes/issues/33