### PR TITLE
#41 - Don't run Doclint for javadoc for JDK 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,6 +269,7 @@
                                     <link>http://docs.spring.io/spring/docs/1.2.x/api/</link>
                                     <link>http://commons.apache.org/proper/commons-logging/apidocs/</link>
                                 </links>
+                                <additionalparam>${javadoc.opts}</additionalparam>
                             </configuration>
                         </execution>
                     </executions>
@@ -295,6 +296,15 @@
             <modules>
                 <module>webtests</module>
             </modules>
+        </profile>
+        <profile>
+            <id>doclint-java8-disable</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <javadoc.opts>-Xdoclint:none</javadoc.opts>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -305,6 +305,17 @@
             <properties>
                 <javadoc.opts>-Xdoclint:none</javadoc.opts>
             </properties>
+          <build>
+            <plugins>
+              <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <configuration>
+                  <skip>true</skip>
+                </configuration>
+              </plugin>
+            </plugins>
+          </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Circumvents issue #41 by not running the doclint for javadoc when building with jdk8