### PR TITLE
Fixed MockRoundTrip to include getMessages from the Request.

### DIFF
--- a/stripes/src/main/java/net/sourceforge/stripes/mock/MockRoundtrip.java
+++ b/stripes/src/main/java/net/sourceforge/stripes/mock/MockRoundtrip.java
@@ -23,6 +23,7 @@ import java.util.TreeMap;
 import javax.servlet.Filter;
 
 import net.sourceforge.stripes.action.ActionBean;
+import net.sourceforge.stripes.action.Message;
 import net.sourceforge.stripes.controller.ActionResolver;
 import net.sourceforge.stripes.controller.AnnotatedClassActionResolver;
 import net.sourceforge.stripes.controller.StripesConstants;
@@ -284,6 +285,23 @@ public class MockRoundtrip {
     public ValidationErrors getValidationErrors() {
         ActionBean bean = (ActionBean) this.request.getAttribute(StripesConstants.REQ_ATTR_ACTION_BEAN);
         return bean.getContext().getValidationErrors();
+    }
+
+    /**
+     * Gets the {@link List} of {@link Message}s that were produced by the request.
+     * This should be used instead of obtaining the messages from the
+     * {@link net.sourceforge.stripes.action.ActionBeanContext} as the context is bound to the
+     * {@link net.sourceforge.stripes.controller.FlashScope}.
+     *
+     * @return
+     */
+    public List<Message> getMessages() {
+        Object attribute = this.request.getAttribute(StripesConstants.REQ_ATTR_MESSAGES);
+        if (attribute == null) {
+            return null;
+        }
+
+        return (List<Message>) attribute;
     }
 
     /**

--- a/stripes/src/test/java/net/sourceforge/stripes/mock/TestContext.java
+++ b/stripes/src/test/java/net/sourceforge/stripes/mock/TestContext.java
@@ -1,0 +1,77 @@
+package net.sourceforge.stripes.mock;
+
+import net.sourceforge.stripes.StripesTestFixture;
+import net.sourceforge.stripes.action.*;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+/**
+ * @author JC Carrillo
+ */
+public class TestContext {
+
+    private static final String MESSAGE = "This is a message";
+
+    @UrlBinding("/simple")
+    public static class ContextActionBean implements ActionBean {
+
+        private ActionBeanContext context;
+
+        @DefaultHandler
+        public Resolution view() {
+            return null;
+        }
+
+        public Resolution messages() {
+            getContext().getMessages().add(new SimpleMessage(MESSAGE));
+            return null;
+        }
+
+        public void setContext(ActionBeanContext context) {
+            this.context = context;
+        }
+
+        public ActionBeanContext getContext() {
+            return context;
+        }
+    }
+
+    @Test
+    public void testMessagesNothingInContext() throws Exception {
+        MockServletContext c = StripesTestFixture.createServletContext();
+        MockRoundtrip mockRoundtrip = new MockRoundtrip(c, ContextActionBean.class);
+        mockRoundtrip.execute();
+        ContextActionBean contextActionBean = mockRoundtrip.getActionBean(ContextActionBean.class);
+        ActionBeanContext context = contextActionBean.getContext();
+        Assert.assertNotNull(context);
+        List<Message> messages = context.getMessages();
+        Assert.assertNotNull(messages);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testMessagesWithMessages() throws Exception {
+        MockServletContext c = StripesTestFixture.createServletContext();
+        MockRoundtrip mockRoundtrip = new MockRoundtrip(c, ContextActionBean.class);
+        mockRoundtrip.execute("messages");
+        ContextActionBean contextActionBean = mockRoundtrip.getActionBean(ContextActionBean.class);
+        ActionBeanContext context = contextActionBean.getContext();
+        Assert.assertNotNull(context);
+        List<Message> messages = context.getMessages();
+        Assert.assertNotNull(messages);
+    }
+
+    @Test
+    public void testMessages() throws Exception {
+        MockServletContext c = StripesTestFixture.createServletContext();
+        final MockRoundtrip mockRoundtrip = new MockRoundtrip(c, ContextActionBean.class);
+        mockRoundtrip.execute("messages");
+        List<Message> messages = mockRoundtrip.getMessages();
+        Assert.assertNotNull(messages);
+        Assert.assertEquals(1, messages.size());
+        Message message = messages.get(0);
+        Assert.assertTrue(message instanceof SimpleMessage);
+        Assert.assertEquals(MESSAGE, ((SimpleMessage) message).getMessage());
+    }
+}


### PR DESCRIPTION
This patch allows for the retrieval ActionBeanContext Messages.

The following fails as the FlashScope is completed after execution and the messages are obtained from it, hence, an NPE is thrown.
```
        mockRoundtrip.execute();
        SomeActionBean bean = mockRoundtrip.getActionBean(SomeActionBean.class);
        ActionBeanContext context = bean.getContext();
        List<Message> messages = context.getMessages();
```

Instead, with this patch, a user can do the following:
```
        mockRoundtrip.execute();
        List<Message> messages = mockRoundtrip.getMessages();
```
and the messages are returned as expected.