### PR TITLE
Method invokes inefficient Number constructor; use static valueOf instead

### DIFF
--- a/stripes/src/main/java/net/sourceforge/stripes/controller/DispatcherHelper.java
+++ b/stripes/src/main/java/net/sourceforge/stripes/controller/DispatcherHelper.java
@@ -393,7 +393,7 @@ public class DispatcherHelper {
 
                     ValidationMethod ann1 = o1.getAnnotation(ValidationMethod.class);
                     ValidationMethod ann2 = o2.getAnnotation(ValidationMethod.class);
-                    int returnValue = new Integer(ann1.priority()).compareTo(ann2.priority());
+                    int returnValue = Integer.valueOf(ann1.priority()).compareTo(ann2.priority());
 
                     if (returnValue == 0) {
                         returnValue = o1.getName().compareTo(o2.getName());

--- a/stripes/src/main/java/net/sourceforge/stripes/controller/FlashScope.java
+++ b/stripes/src/main/java/net/sourceforge/stripes/controller/FlashScope.java
@@ -322,7 +322,7 @@ public class FlashScope extends HashMap<String,Object> {
         }
         else {
             try {
-                Integer id = new Integer(keyString);
+                Integer id = Integer.valueOf(keyString);
                 Map<Integer, FlashScope> scopes = getContainer(req, false);
                 return scopes == null ? null : scopes.remove(id);
             }

--- a/stripes/src/main/java/net/sourceforge/stripes/controller/ParameterName.java
+++ b/stripes/src/main/java/net/sourceforge/stripes/controller/ParameterName.java
@@ -91,7 +91,7 @@ public class ParameterName implements Comparable<ParameterName> {
      *         parameter passed in sorts first.
      */
     public int compareTo(ParameterName that) {
-        int result = new Integer(this.name.length()).compareTo(that.name.length());
+        int result = Integer.valueOf(this.name.length()).compareTo(that.name.length());
         if (result == 0) {
             result = this.name.compareTo(that.name);
         }

--- a/stripes/src/main/java/net/sourceforge/stripes/util/ReflectUtil.java
+++ b/stripes/src/main/java/net/sourceforge/stripes/util/ReflectUtil.java
@@ -85,12 +85,12 @@ public class ReflectUtil {
 
         primitiveDefaults.put(Boolean.TYPE,    false);
         primitiveDefaults.put(Character.TYPE, '\0');
-        primitiveDefaults.put(Byte.TYPE,       new Byte("0"));
-        primitiveDefaults.put(Short.TYPE,      new Short("0"));
-        primitiveDefaults.put(Integer.TYPE,    new Integer(0));
-        primitiveDefaults.put(Long.TYPE,       new Long(0l));
-        primitiveDefaults.put(Float.TYPE,      new Float(0f));
-        primitiveDefaults.put(Double.TYPE,     new Double(0.0));
+        primitiveDefaults.put(Byte.TYPE,       Byte.valueOf("0"));
+        primitiveDefaults.put(Short.TYPE,      Short.valueOf("0"));
+        primitiveDefaults.put(Integer.TYPE,    Integer.valueOf(0));
+        primitiveDefaults.put(Long.TYPE,       Long.valueOf(0l));
+        primitiveDefaults.put(Float.TYPE,      Float.valueOf(0f));
+        primitiveDefaults.put(Double.TYPE,     Double.valueOf(0.0));
     }
 
     /**

--- a/stripes/src/main/java/net/sourceforge/stripes/validation/ByteTypeConverter.java
+++ b/stripes/src/main/java/net/sourceforge/stripes/validation/ByteTypeConverter.java
@@ -44,7 +44,7 @@ public class ByteTypeConverter extends NumberTypeConverterSupport implements Typ
                                                        Byte.MIN_VALUE, Byte.MAX_VALUE) );
             }
             else {
-                retval = new Byte((byte) output);
+                retval = Byte.valueOf((byte) output);
             }
         }
 

--- a/stripes/src/main/java/net/sourceforge/stripes/validation/IntegerTypeConverter.java
+++ b/stripes/src/main/java/net/sourceforge/stripes/validation/IntegerTypeConverter.java
@@ -44,7 +44,7 @@ public class IntegerTypeConverter extends NumberTypeConverterSupport implements 
                                                        Integer.MIN_VALUE, Integer.MAX_VALUE) );
             }
             else {
-                retval = new Integer((int) output);
+                retval = Integer.valueOf((int) output);
             }
         }
 

--- a/stripes/src/main/java/net/sourceforge/stripes/validation/LongTypeConverter.java
+++ b/stripes/src/main/java/net/sourceforge/stripes/validation/LongTypeConverter.java
@@ -36,7 +36,7 @@ public class LongTypeConverter extends NumberTypeConverterSupport implements Typ
         Number number = parse(input, errors);
         Long retval = null;
         if (errors.size() == 0) {
-            retval = new Long(number.longValue());
+            retval = Long.valueOf(number.longValue());
         }
 
         return retval;

--- a/stripes/src/main/java/net/sourceforge/stripes/validation/ShortTypeConverter.java
+++ b/stripes/src/main/java/net/sourceforge/stripes/validation/ShortTypeConverter.java
@@ -44,7 +44,7 @@ public class ShortTypeConverter extends NumberTypeConverterSupport implements Ty
                                                        Short.MIN_VALUE, Short.MAX_VALUE) );
             }
             else {
-                retval = new Short((short) output);
+                retval = Short.valueOf((short) output);
             }
         }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Findbugs rule DM_NUMBER_CTOR - “ Method invokes inefficient Number constructor; use static valueOf instead ”. You can find more information about the issue here: http://findbugs.sourceforge.net/bugDescriptions.html#DM_NUMBER_CTOR
Please let me know if you have any questions.
Ayman Abdelghany.