### PR TITLE
Retain Java 6 compatibility.

### DIFF
--- a/stripes/src/main/java/net/sourceforge/stripes/controller/StripesRequestWrapper.java
+++ b/stripes/src/main/java/net/sourceforge/stripes/controller/StripesRequestWrapper.java
@@ -294,7 +294,7 @@ public class StripesRequestWrapper extends HttpServletRequestWrapper {
         if (this.contentTypeRequestWrapper != null && MultipartWrapper.class.isAssignableFrom(this.contentTypeRequestWrapper.getClass())) {
             return ((MultipartWrapper) this.contentTypeRequestWrapper).getFileParameterNames();
         } else {
-            return Collections.emptyEnumeration();
+            return Collections.enumeration(Collections.<String>emptyList());
         }
     }
 


### PR DESCRIPTION
https://github.com/StripesFramework/stripes/commit/b1ac43ba6ac7085b666328e7f94937bb6401cdf5
The commit message says Java 7, but the parent pom.xml uses Java 6 ;-)
And this line seems to be the only Java-6-incompatible call.