### PR TITLE
Fix issues when a single request is forwarded to multiple ActionBeans.

### DIFF
--- a/stripes/src/main/java/net/sourceforge/stripes/controller/AnnotatedClassActionResolver.java
+++ b/stripes/src/main/java/net/sourceforge/stripes/controller/AnnotatedClassActionResolver.java
@@ -370,21 +370,24 @@ public class AnnotatedClassActionResolver implements ActionResolver {
         }
 
         String bindingPath = getUrlBinding(beanClass);
+        final String contextPath = context.getServletContext().getContextPath() != null ?
+                context.getServletContext().getContextPath() : "";
+        final String attribName = contextPath + bindingPath;
         try {
             HttpServletRequest request = context.getRequest();
 
             if (beanClass.isAnnotationPresent(SessionScope.class)) {
-                bean = (ActionBean) request.getSession().getAttribute(bindingPath);
+                bean = (ActionBean) request.getSession().getAttribute(attribName);
 
                 if (bean == null) {
                     bean = makeNewActionBean(beanClass, context);
-                    request.getSession().setAttribute(bindingPath, bean);
+                    request.getSession().setAttribute(attribName, bean);
                 }
             } else {
-                bean = (ActionBean) request.getAttribute(bindingPath);
+                bean = (ActionBean) request.getAttribute(attribName);
                 if (bean == null) {
                     bean = makeNewActionBean(beanClass, context);
-                    request.setAttribute(bindingPath, bean);
+                    request.setAttribute(attribName, bean);
                 }
             }
 

--- a/stripes/src/main/java/net/sourceforge/stripes/controller/DispatcherServlet.java
+++ b/stripes/src/main/java/net/sourceforge/stripes/controller/DispatcherServlet.java
@@ -340,10 +340,10 @@ public class DispatcherServlet extends HttpServlet {
      * @return the Stack if present, or if creation is requested
      */
     @SuppressWarnings("unchecked")
-	protected Stack<ActionBean> getActionBeanStack(HttpServletRequest request, boolean create) {
-        Stack<ActionBean> stack = (Stack<ActionBean>) request.getAttribute(StripesConstants.REQ_ATTR_ACTION_BEAN_STACK);
+	protected Stack<Object> getActionBeanStack(HttpServletRequest request, boolean create) {
+        Stack<Object> stack = (Stack<Object>) request.getAttribute(StripesConstants.REQ_ATTR_ACTION_BEAN_STACK);
         if (stack == null && create) {
-            stack = new Stack<ActionBean>();
+            stack = new Stack<Object>();
             request.setAttribute(StripesConstants.REQ_ATTR_ACTION_BEAN_STACK, stack);
         }
 
@@ -359,8 +359,8 @@ public class DispatcherServlet extends HttpServlet {
      */
     protected void saveActionBean(HttpServletRequest request) {
         if (request.getAttribute(StripesConstants.REQ_ATTR_ACTION_BEAN) != null) {
-            Stack<ActionBean> stack = getActionBeanStack(request, true);
-            stack.push((ActionBean) request.getAttribute(StripesConstants.REQ_ATTR_ACTION_BEAN));
+            Stack<Object> stack = getActionBeanStack(request, true);
+            stack.push(request.getAttribute(StripesConstants.REQ_ATTR_ACTION_BEAN));
         }
     }
 
@@ -372,7 +372,7 @@ public class DispatcherServlet extends HttpServlet {
      * @param request the current HttpServletRequest
      */
     protected void restoreActionBean(HttpServletRequest request) {
-        Stack<ActionBean> stack = getActionBeanStack(request, false);
+        Stack<Object> stack = getActionBeanStack(request, false);
         if (stack != null && !stack.empty()) {
             request.setAttribute(StripesConstants.REQ_ATTR_ACTION_BEAN, stack.pop());
         }

--- a/stripes/src/main/java/net/sourceforge/stripes/mock/MockRoundtrip.java
+++ b/stripes/src/main/java/net/sourceforge/stripes/mock/MockRoundtrip.java
@@ -274,9 +274,12 @@ public class MockRoundtrip {
      */
     @SuppressWarnings("unchecked")
 	public <A extends ActionBean> A getActionBean(Class<A> type) {
-        A bean = (A) this.request.getAttribute(getUrlBinding(type, this.context));
+        final String bindingPath = getUrlBinding(type, this.context);
+        final String contextPath = context.getContextPath() != null ? context.getContextPath() : "";
+        final String attribName = contextPath + bindingPath;
+        A bean = (A) this.request.getAttribute(attribName);
         if (bean == null) {
-            bean = (A) this.request.getSession().getAttribute(getUrlBinding(type, this.context));
+            bean = (A) this.request.getSession().getAttribute(attribName);
         }
         return bean;
     }


### PR DESCRIPTION
I develop plugins for a product which provides a portal solution. In this software a plugin is basically a standalone java webapp that runs in the Tomcat container alongside the core product. Stripes works well in most scenarios except one.

The product has portlets which are basically boxes on the page that load the contents of other pages. Tomcat forwards control to each module's URL to render each portlets the content into the response. I.e. the `DispatcherServelet` is called multiple times to fulfill a single request 

It appears from the source that this is a scenario that Stripes attempts to handle. When the `DispatcherServlet` encounters an `Object` already in the `actionBean` request parameter, it casts the object to an `ActionBean` and pushes it onto a stack. It then restores it back again after processing. This works well, except when the `ActionBean` that is already in the request was loaded by an inaccessible class loader. 

When Stripes attempts to cast the `Object` already in the `actionBean` request parameter to an `ActionBean` it can't because it doesn't have the class data. In this instance, a `ClassCastException` is thrown. 

There is no need to cast this to an `ActionBean` at all. As described above, the `Object` in the request parameter is simply pushed onto a stack and restored back after. It is never actually used as an `ActionBean` during its time on the stack. The cast to `ActionBean` is unnecessary work even ignoring this issue.

There is one other issue with the scenario I have described. Specifically the `AnnotatedClassActionResolver` assumes that the `UrlBinding` of an `ActionBean` is going to be unique, but this is not necessarily the case. Stripes may be running in multiple separate webapp contexts. It is the combination of context path and `UrlBinding` that is unique. This pull request also addresses this.

Combining everything into a single webapp is not an option, as we do not have control over what clients install. Other developers may also choose to use Stripes.

Please let me know if there is any other information or clarification I can offer.