### PR TITLE
Fix Tomcat crossContext

### DIFF
--- a/stripes/src/main/java/net/sourceforge/stripes/controller/AnnotatedClassActionResolver.java
+++ b/stripes/src/main/java/net/sourceforge/stripes/controller/AnnotatedClassActionResolver.java
@@ -370,21 +370,24 @@ public class AnnotatedClassActionResolver implements ActionResolver {
         }
 
         String bindingPath = getUrlBinding(beanClass);
+        final String contextPath = context.getServletContext().getContextPath() != null ?
+                context.getServletContext().getContextPath() : "";
+        final String attribName = contextPath + bindingPath;
         try {
             HttpServletRequest request = context.getRequest();
 
             if (beanClass.isAnnotationPresent(SessionScope.class)) {
-                bean = (ActionBean) request.getSession().getAttribute(bindingPath);
+                bean = (ActionBean) request.getSession().getAttribute(attribName);
 
                 if (bean == null) {
                     bean = makeNewActionBean(beanClass, context);
-                    request.getSession().setAttribute(bindingPath, bean);
+                    request.getSession().setAttribute(attribName, bean);
                 }
             } else {
-                bean = (ActionBean) request.getAttribute(bindingPath);
+                bean = (ActionBean) request.getAttribute(attribName);
                 if (bean == null) {
                     bean = makeNewActionBean(beanClass, context);
-                    request.setAttribute(bindingPath, bean);
+                    request.setAttribute(attribName, bean);
                 }
             }
 

--- a/stripes/src/main/java/net/sourceforge/stripes/controller/DispatcherServlet.java
+++ b/stripes/src/main/java/net/sourceforge/stripes/controller/DispatcherServlet.java
@@ -375,6 +375,8 @@ public class DispatcherServlet extends HttpServlet {
         Stack<ActionBean> stack = getActionBeanStack(request, false);
         if (stack != null && !stack.empty()) {
             request.setAttribute(StripesConstants.REQ_ATTR_ACTION_BEAN, stack.pop());
+        } else {
+            request.removeAttribute(StripesConstants.REQ_ATTR_ACTION_BEAN);
         }
     }
 }

--- a/stripes/src/main/java/net/sourceforge/stripes/controller/StripesConstants.java
+++ b/stripes/src/main/java/net/sourceforge/stripes/controller/StripesConstants.java
@@ -66,6 +66,12 @@ public interface StripesConstants {
     String REQ_ATTR_ACTION_BEAN = "actionBean";
 
     /**
+     * The name under which the last ActionBean for a request is stored before restoring from
+     * the stack.
+     */
+    String REQ_ATTR_LAST_ACTION_BEAN = "lastActionBean";
+
+    /**
      * The name of a request attribute in which a Stack of action beans is some times stored
      * when a single request involves includes of action beans.
      */

--- a/stripes/src/main/java/net/sourceforge/stripes/mock/MockRoundtrip.java
+++ b/stripes/src/main/java/net/sourceforge/stripes/mock/MockRoundtrip.java
@@ -274,9 +274,12 @@ public class MockRoundtrip {
      */
     @SuppressWarnings("unchecked")
 	public <A extends ActionBean> A getActionBean(Class<A> type) {
-        A bean = (A) this.request.getAttribute(getUrlBinding(type, this.context));
+        final String bindingPath = getUrlBinding(type, this.context);
+        final String contextPath = context.getContextPath() != null ? context.getContextPath() : "";
+        final String attribName = contextPath + bindingPath;
+        A bean = (A) this.request.getAttribute(attribName);
         if (bean == null) {
-            bean = (A) this.request.getSession().getAttribute(getUrlBinding(type, this.context));
+            bean = (A) this.request.getSession().getAttribute(attribName);
         }
         return bean;
     }

--- a/stripes/src/main/java/net/sourceforge/stripes/mock/MockRoundtrip.java
+++ b/stripes/src/main/java/net/sourceforge/stripes/mock/MockRoundtrip.java
@@ -285,7 +285,7 @@ public class MockRoundtrip {
      * Gets the (potentially empty) set of Validation Errors that were produced by the request.
      */
     public ValidationErrors getValidationErrors() {
-        ActionBean bean = (ActionBean) this.request.getAttribute(StripesConstants.REQ_ATTR_ACTION_BEAN);
+        ActionBean bean = (ActionBean) this.request.getAttribute(StripesConstants.REQ_ATTR_LAST_ACTION_BEAN);
         return bean.getContext().getValidationErrors();
     }
 

--- a/stripes/src/test/java/net/sourceforge/stripes/StripesTestFixture.java
+++ b/stripes/src/test/java/net/sourceforge/stripes/StripesTestFixture.java
@@ -55,6 +55,7 @@ public class StripesTestFixture {
     public static Map<String, String> getDefaultFilterParams() {
         Map<String, String> map = new HashMap<String, String>();
         map.put("ActionResolver.Packages", "net.sourceforge.stripes");
+        map.put("Interceptor.Classes", "net.sourceforge.stripes.test.RecordLastActionBeanInterceptor");
         map.put("LocalePicker.Class", "net.sourceforge.stripes.localization.MockLocalePicker");
         return map;
     }

--- a/stripes/src/test/java/net/sourceforge/stripes/test/RecordLastActionBeanInterceptor.java
+++ b/stripes/src/test/java/net/sourceforge/stripes/test/RecordLastActionBeanInterceptor.java
@@ -1,0 +1,18 @@
+package net.sourceforge.stripes.test;
+
+import net.sourceforge.stripes.action.Resolution;
+import net.sourceforge.stripes.controller.*;
+
+/**
+ * Created by shane on 23/9/16.
+ */
+@Intercepts(LifecycleStage.RequestComplete)
+public class RecordLastActionBeanInterceptor implements Interceptor {
+
+    @Override
+    public Resolution intercept(ExecutionContext context) throws Exception {
+        context.getActionBeanContext().getRequest().setAttribute(StripesConstants.REQ_ATTR_LAST_ACTION_BEAN, context.getActionBean());
+        return null;
+    }
+
+}


### PR DESCRIPTION
This pull request replaced pull request #62. After discussions with @rgrashel, I believe this is a better resolution to the issue.

This resolves issues related to the use of [Tomcat's `crossContext` configuration item](https://tomcat.apache.org/tomcat-7.0-doc/config/context.html). When this config item is set to `true` a single request may include/forward control across servlets from different contexts. Which results in two different issues. 

The first is that the final actionBean in the stack is left in the `actionBean` request attribute at the end, so when Stripes (running in a second context) attempts to service a request there is already a bean in this attribute. This is resolved by clearing the request attribute when the stack is empty. This make sense as the idea behind the `restoreActionBean` method is to remove the current action bean and restore the existing one. This change means that it clears the current bean (as expected) even when there is nothing left in the stack to put back in its place.

The second issue is that URL bindings may not be unique across contexts. This is a problem when stripes stores the actionBean for a URL in the session. This is resolved by prepending the context path to the request attribute name.

As with the last pull request, it is difficult to write tests for this as none of the mock round trip infrastructure was written with `crossContext` in mind. I could write some tests that check that the `actionBean` request attribute has been unset after servicing a request, but I feel this would be testing implementation, instead of behaviour. Please let me know your feelings on this.

All existing tests pass.

Please let me know if there is anything you'd like me to change or clarify.

Cheers,
Shane.