### PR TITLE
Update AnnotatedClassActionResolver.java

### DIFF
--- a/stripes/src/main/java/net/sourceforge/stripes/controller/AnnotatedClassActionResolver.java
+++ b/stripes/src/main/java/net/sourceforge/stripes/controller/AnnotatedClassActionResolver.java
@@ -264,10 +264,25 @@ public class AnnotatedClassActionResolver implements ActionResolver {
         if (superclass != null) {
             processMethods(superclass, classMappings);
         }
+        
+        Class<?>[] clazzes = clazz.getInterfaces();
+        for(Class<?> interfaceClazz : clazzes){
+            Method[] methods = interfaceClazz.getDeclaredMethods();
+            for (Method method : methods) {
+                if(method.isDefault()){
+                    processMethod(clazz, classMappings, method);
+                }
+            }
+        }
 
         Method[] methods = clazz.getDeclaredMethods();
         for (Method method : methods) {
-            if (Modifier.isPublic(method.getModifiers()) && !method.isBridge()) {
+            processMethod(clazz, classMappings, method);
+        }
+    }
+    
+    protected void processMethod(Class<?> clazz, Map<String, Method> classMappings, Method method) {
+        if (Modifier.isPublic(method.getModifiers()) && !method.isBridge()) {
                 String eventName = getHandledEvent(method);
 
                 // look for duplicate event names within the current class
@@ -292,7 +307,6 @@ public class AnnotatedClassActionResolver implements ActionResolver {
                     // Makes sure we catch the default handler
                     classMappings.put(DEFAULT_HANDLER_KEY, method);
                 }
-            }
         }
     }
 


### PR DESCRIPTION
Add support for Java 8 default method in interfaces as an event handler. It looks like the getDeclaredMethods does not return default method in interface implemented by the ActionBean.

Note: the method.isDefault() require java 8. So I don't know what is the minimum JDK supported by Stripes, but this patch would require at least Java 8