### PR TITLE
Update some dependencies to current releases

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -45,34 +45,29 @@
         </dependency>
         <dependency>
             <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
+            <artifactId>javax.mail-api</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.0.1</version>
             <scope>compile</scope>
         </dependency>
-
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpasyncclient</artifactId>
-            <version>4.0.2</version>
+            <version>4.1.4</version>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,8 @@
             </dependency>
             <dependency>
                 <groupId>javax.mail</groupId>
-                <artifactId>mail</artifactId>
-                <version>1.4.7</version>
+                <artifactId>javax.mail-api</artifactId>
+                <version>1.6.1</version>
                 <scope>provided</scope>
                 <optional>true</optional>
                 <exclusions>
@@ -99,13 +99,13 @@
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <version>6.8.8</version>
+                <version>6.14.3</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
-                <version>1.1.3</version>
+                <version>1.2</version>
                 <exclusions>
                     <exclusion>
                         <groupId>javax.servlet</groupId>
@@ -162,23 +162,28 @@
             <dependency>
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>
-                <version>1.3.1</version>
+                <version>1.3.3</version>
                 <scope>provided</scope>
                 <optional>true</optional>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.0.1</version>
+                <version>2.9.6</version>
                 <scope>provided</scope>
                 <optional>true</optional>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.0.1</version>
+                <version>2.9.6</version>
                 <scope>provided</scope>
                 <optional>true</optional>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>2.9.6</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
             <dependency>
                 <groupId>javax.mail</groupId>
                 <artifactId>javax.mail-api</artifactId>
-                <version>1.6.1</version>
+                <version>1.6.2</version>
                 <scope>provided</scope>
                 <optional>true</optional>
                 <exclusions>
@@ -169,21 +169,21 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.9.6</version>
+                <version>2.9.8</version>
                 <scope>provided</scope>
                 <optional>true</optional>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.9.6</version>
+                <version>2.9.8</version>
                 <scope>provided</scope>
                 <optional>true</optional>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.9.6</version>
+                <version>2.9.8</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/stripes/pom.xml
+++ b/stripes/pom.xml
@@ -36,7 +36,7 @@
         </dependency>
         <dependency>
             <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
+            <artifactId>javax.mail-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>
@@ -65,12 +65,10 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.0.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- commons-fileupload:commons-fileupload (1.3.1 -> 1.3.3)
- commons-logging:commons-logging (1.1.3 -> 1.2)
- org.testng:testng (6.8.8 -> 6.14.3)
- javax.mail:mail 1.4.7 -> javax.javax.mail-api 1.6.2
- com.fasterxml.jackson.core:jackson-core (2.0.1 -> 2.9.8)
- com.fasterxml.jackson.core:jackson-databind (2.0.1 -> 2.9.8)
- com.fasterxml.jackson.core:jackson-annotations (2.0.1 -> 2.9.8)
- org.apache.httpcomponents:httpasyncclient (4.0.2 -> 4.1.4)

Not sure about updating the Spring dependency, so omitted. To get a list of available updates you can use the Codehaus versions plugin: `mvn -U org.codehaus.mojo:versions-maven-plugin:display-dependency-updates -T1 > dependency-updates.log`

NB. I can recommend registering this repository at Dependabot for automated dependency update PRs. see: https://app.dependabot.com/